### PR TITLE
[kit] `setContent` needs to be called for layout resets

### DIFF
--- a/src/routes/guides/setting-up-your-project.svx
+++ b/src/routes/guides/setting-up-your-project.svx
@@ -73,7 +73,7 @@ export default {
 ```
 
 And finally, we need to configure our application to use the generated network layer. To do
-this, add the following block of code to `src/routes/__layout.svelte`:
+this, add the following block of code to `src/routes/__layout.svelte` and any `__layout.reset.svelte` files:
 
 ```html
 <script context="module">


### PR DESCRIPTION
Maybe this is obvious for some but I just got bitten by the fact that you also need to `setEnvironment` in any layout resets where you want to use houdini.

In hindsight this should be really obvious but in dev mode it did work without the second `setEnvironment`...