### PR TITLE
Adding tip to use -p flag to regenerate schema

### DIFF
--- a/src/routes/intro/fetching-data.svx
+++ b/src/routes/intro/fetching-data.svx
@@ -113,6 +113,12 @@ npm run generate
 
 Keep in mind, you will have to do this every time you change any graphql string in a houdini project. I know this sounds like a big burden but bear with us. We are actively working on a way to avoid this altogether, its just not ready yet.
 
+Once you make changes to the Grapqhl server's schema, we will have to tell Houidini to regenerate the files.  In order to do this, invoke the compiler with:
+
+```bash
+npm run generate -p
+```
+
 Now that you've generated the necessary files, you should see a description of the first species in the generation 1 Pokédex - the ever popular Bulbasaur. If you are still running into issues, please reach out to us on the svelte discord and we'd be happy to help.
 
 <DeepDive title="What happened to load?">


### PR DESCRIPTION
Not sure what verbiage is best, or if it should be a special call out, but it would help new users to understand that `generate` does not refresh the local file. 

It needs the -p option: https://www.houdinigraphql.com/api/cli#generate

I burnt time figuring this out and maybe can save people after me some time.