### PR TITLE
Fix SvelteKit code examples

### DIFF
--- a/src/routes/guides/setting-up-your-project.svx
+++ b/src/routes/guides/setting-up-your-project.svx
@@ -70,8 +70,6 @@ export default {
 Next, you need to update your `vite.config.js` to look like:
 
 ```javascript
-import path from 'path'
-
 export default {
 	server: {
 		fs: {
@@ -86,7 +84,7 @@ this, add the following block of code to `src/routes/__layout.svelte` and any `_
 
 ```html
 <script context="module">
-	import houdiniClient from '../client'
+	import houdiniClient from '../houdiniClient'
 
 	houdiniClient.init()
 </script>


### PR DESCRIPTION
Removed unused `path` import and fixed import of `houdiniClient`.

Fixes #19.