### PR TITLE
Declare import explicitly as a type

### DIFF
--- a/src/routes/api/query/inline.svx
+++ b/src/routes/api/query/inline.svx
@@ -68,7 +68,7 @@ modified example [from the source repository](https://github.com/HoudiniGraphql/
 
 <!-- src/routes/[filter].svelte -->
 <script lang="ts">
-	import { query, graphql, AllItems } from '$houdini'
+	import { query, graphql, type AllItems } from '$houdini'
 
 	// load the items
 	const { data } = query<AllItems>(graphql`


### PR DESCRIPTION
I think that is more clear for non-TypeScript users that they don't need to import AllItems.

I have seen `import { type ... }` elsewhere in the codebase. Hope that makes sense in this case.